### PR TITLE
Change np.float to float in biostats.py

### DIFF
--- a/qqman/biostats.py
+++ b/qqman/biostats.py
@@ -8,9 +8,9 @@ def ppoints(n, a=None):
 		:param n: array type or number"""
 	
 	if isinstance(n, numbers.Number):
-		n = np.float(n)
+		n = float(n)
 	else:
-		n = np.float(len(n))
+		n = float(len(n))
 	if a == None:
 		a = .375 if n<=10 else .5
 		


### PR DESCRIPTION
`np.float` is deprecated in newer versions of numpy (https://stackoverflow.com/questions/74844262/how-can-i-solve-error-module-numpy-has-no-attribute-float-in-python) causing the `ppoints` function to break. I changed these to `float` to avoid this.